### PR TITLE
use HIP_PATH to add the module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,17 @@ else()
   set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories")
 endif()
 
+# Get HIP_PATH
+if( NOT DEFINED ENV{HIP_PATH} )
+  set( HIP_PATH "/opt/rocm/hip" )
+else()
+  set( HIP_PATH $ENV{HIP_PATH} )
+endif()
+
 # CMake modules
 list(APPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake
-     /opt/rocm/hip/cmake
+     ${HIP_PATH}/cmake
 )
 
 # Set a default build type if none was specified


### PR DESCRIPTION
when install hip in custom directory, the module path still uses `/opt/rocm/hip/cmake`
Use the same way in hipBLAS to detect `HIP_PATH` from environment or cmake setting, 
and use `HIP_PATH` to set the corresponding module path